### PR TITLE
Separate the EKS auth and kubectl config from deployment.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,9 @@ ADD https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/am
 ADD https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/aws-iam-authenticator /usr/bin/aws-iam-authenticator
 RUN chmod +x /usr/bin/kubectl /usr/bin/aws-iam-authenticator
 
-# Install the Drone plugin script
+# Install the Drone plugin scripts
 COPY update.sh /bin/
+COPY connect-eks.sh /bin/
 
 ENTRYPOINT ["/bin/bash"]
 CMD ["/bin/update.sh"]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ secrets and can take advantage of the IAM security model.
 Inspired by the work in https://github.com/honestbee/drone-kubernetes which is
 a great option for any non-EKS K8 environments.
 
-# Usage
+# Usage (in deployment mode)
 
 | Argument        | Required? | Details                                                                                         |
 |-----------------|-----------|-------------------------------------------------------------------------------------------------|
@@ -19,6 +19,7 @@ a great option for any non-EKS K8 environments.
 | EKS_CLUSTER     | required  | Name of the EKS cluster, as show in the EKS console/API.                                        |
 | REPO            | required  | Docker image repository (eg `6789.dkr.ecr.us-east-1.amazonaws.com/sampleapp`)                   |
 | TAG             | required  | Docker image tag (eg `latest`)                                                                  |
+| NAMESPACE       | required  | Which Kubernetes namespace to operate in.                                                       |
 | DEPLOYMENT      | required  | Kubernetes deployment to modify.                                                                |
 | CONTAINER       | required  | Name of the container inside the deployment to update.                                          |
 | AWS_REGION      | optional  | Region where the EKS cluster is located. Defaults to the same region as the Drone build agent.  |
@@ -36,6 +37,44 @@ For example, a typical deployment statement:
       tag: latest
       when:
         branch: master
+
+
+# Usage (in commands mode)
+
+In some situations, you may have an application that requires some very specific
+handling with `kubectl` - for example, you may need to run some queries, update
+a config map or do something else that isn't the typical "deploy a new container"
+type task.
+
+To support this use case, this plugin can be executed as a regular container in
+Drone with commands passed to it. The way to execute changes somewhat compared
+to doing a deployment, since we need to pass the configuration parameters as
+environmentals rather than arguments to the plugin.
+
+    do-something-with-kubectl:
+      image: drone-eks-plugin:latest
+      pull: true
+      commands:
+        - /bin/connect-eks.sh
+        - kubectl get pods # replace with your desired commands.
+      environment:
+        PLUGIN_IAM_ROLE_ARN: arn:aws:iam::123456789:role/k8-deployer-role
+        PLUGIN_EKS_CLUSTER: myfirstcluster
+
+| Environmental   | Required? | Details                                                                                         |
+|-----------------|-----------|-------------------------------------------------------------------------------------------------|
+| IAM_ROLE_ARN    | required  | ARN for an IAM role that Drone is permitted to assume that grants Kubernetes deployment rights. |
+| EKS_CLUSTER     | required  | Name of the EKS cluster, as show in the EKS console/API.                                        |
+| AWS_REGION      | optional  | Region where the EKS cluster is located. Defaults to the same region as the Drone build agent.  |
+
+It is required that `/bin/connect-eks.sh` is the first command executed. This
+runs the script that establishes the EKS connection so that `kubectl` is
+correctly configured and ready to use with subsequent commands.
+
+You will also need to adjust the `ClusterRole` that Drone uses, otherwise you
+will receive plenty of `Error from server (Forbidden)`. Take extreme care when
+adjusting these roles, since you may grant more permissions that you intend and
+compromise the security of your Kubernetes cluster.
 
 
 # Installation.

--- a/connect-eks.sh
+++ b/connect-eks.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Establish an authenticated connection to an EKS cluster.
+#
+
+if [ -z ${PLUGIN_EKS_CLUSTER} ]; then
+  echo "EKS_CLUSTER (Name of EKS cluster) must be defined."
+  exit 1
+fi
+
+if [ -z ${PLUGIN_IAM_ROLE_ARN} ]; then
+  echo "IAM_ROLE_ARN (ARN of the IAM role with cluster deploy/management perms) must be defined."
+  exit 1
+fi
+
+if [ -z ${PLUGIN_AWS_REGION} ]; then
+  # Try to pull the region from the host that is running Drone - this assumes
+  # the Drone EC2 instance is in the same region as the EKS cluster you are
+  # deploying onto. If needed, override with PLUGIN_AWS_REGION param,
+  export AWS_REGION_AND_ZONE=`curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone`
+  export PLUGIN_AWS_REGION=`echo ${AWS_REGION_AND_ZONE} | sed 's/[a-z]$//'`
+
+fi
+export AWS_DEFAULT_REGION=${PLUGIN_AWS_REGION}
+
+
+
+# Fetch the token from the AWS account.
+KUBERNETES_TOKEN=$(aws-iam-authenticator token -i $PLUGIN_EKS_CLUSTER -r $PLUGIN_IAM_ROLE_ARN | jq -r .status.token)
+
+if [ -z $KUBERNETES_TOKEN ]; then
+  echo "Unable to obtain Kubernetes token - check Drone's IAM permissions"
+  echo "Maybe it cannot assume the ${PLUGIN_IAM_ROLE_ARN} role?"
+  exit 1
+fi
+
+
+# Fetch the EKS cluster information.
+EKS_URL=$(aws eks describe-cluster --name ${PLUGIN_EKS_CLUSTER} | jq -r .cluster.endpoint)
+EKS_CA=$(aws eks describe-cluster --name ${PLUGIN_EKS_CLUSTER} | jq -r .cluster.certificateAuthority.data)
+
+if [ -z $EKS_URL ] || [ -z $EKS_CA ]; then
+  echo "Unable to obtain EKS cluster information - check Drone's EKS API permissions"
+  exit 1
+fi
+
+
+# Generate configuration files
+mkdir ~/.kube
+cat > ~/.kube/config << EOF
+apiVersion: v1
+preferences: {}
+kind: Config
+
+clusters:
+- cluster:
+    server: ${EKS_URL}
+    certificate-authority-data: ${EKS_CA}
+  name: eks_${PLUGIN_EKS_CLUSTER}
+
+contexts:
+- context:
+    cluster: eks_${PLUGIN_EKS_CLUSTER}
+    user: eks_${PLUGIN_EKS_CLUSTER}
+  name: eks_${PLUGIN_EKS_CLUSTER}
+
+current-context: eks_${PLUGIN_EKS_CLUSTER}
+
+users:
+- name: eks_${PLUGIN_EKS_CLUSTER}
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1alpha1
+      command: aws-iam-authenticator
+      args:
+        - "token"
+        - "-i"
+        - ${PLUGIN_EKS_CLUSTER}
+        - -r
+        - ${PLUGIN_IAM_ROLE_ARN}
+EOF

--- a/update.sh
+++ b/update.sh
@@ -1,15 +1,13 @@
 #!/bin/bash
 
-if [ -z ${PLUGIN_EKS_CLUSTER} ]; then
-  echo "EKS_CLUSTER (Name of EKS cluster) must be defined."
-  exit 1
-fi
+# Perform a deployment onto Kubernetes by updating an existing K8s deployment
+# with a new container image.
+#
 
-if [ -z ${PLUGIN_IAM_ROLE_ARN} ]; then
-  echo "IAM_ROLE_ARN (ARN of the IAM role with cluster deploy/management perms) must be defined."
-  exit 1
-fi
+# Connect to the EKS cluster.
+source /bin/connect-eks.sh
 
+# Make sure we have information needed for deployment.
 if [ -z ${PLUGIN_REPO} ]; then
   echo "REPO must be defined"
   exit 1
@@ -20,74 +18,23 @@ if [ -z ${PLUGIN_TAG} ]; then
   exit 1
 fi
 
-if [ -z ${PLUGIN_AWS_REGION} ]; then
-  # Try to pull the region from the host that is running Drone - this assumes
-  # the Drone EC2 instance is in the same region as the EKS cluster you are
-  # deploying onto. If needed, override with PLUGIN_AWS_REGION param,
-  export AWS_REGION_AND_ZONE=`curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone`
-  export PLUGIN_AWS_REGION=`echo ${AWS_REGION_AND_ZONE} | sed 's/[a-z]$//'`
-
+if [ -z ${PLUGIN_NAMESPACE} ]; then
+  echo "NAMESPACE must be defined"
+  exit 1
 fi
-export AWS_DEFAULT_REGION=${PLUGIN_AWS_REGION}
 
+if [ -z ${PLUGIN_DEPLOYMENT} ]; then
+  echo "DEPLOYMENT must be defined"
+  exit 1
+fi
 
-
-# Fetch the token from the AWS account.
-KUBERNETES_TOKEN=$(aws-iam-authenticator token -i $PLUGIN_EKS_CLUSTER -r $PLUGIN_IAM_ROLE_ARN | jq -r .status.token)
-
-if [ -z $KUBERNETES_TOKEN ]; then
-  echo "Unable to obtain Kubernetes token - check Drone's IAM permissions"
-  echo "Maybe it cannot assume the ${PLUGIN_IAM_ROLE_ARN} role?"
+if [ -z ${PLUGIN_CONTAINER} ]; then
+  echo "CONTAINER must be defined"
   exit 1
 fi
 
 
-# Fetch the EKS cluster information.
-EKS_URL=$(aws eks describe-cluster --name ${PLUGIN_EKS_CLUSTER} | jq -r .cluster.endpoint)
-EKS_CA=$(aws eks describe-cluster --name ${PLUGIN_EKS_CLUSTER} | jq -r .cluster.certificateAuthority.data)
-
-if [ -z $EKS_URL ] || [ -z $EKS_CA ]; then
-  echo "Unable to obtain EKS cluster information - check Drone's EKS API permissions"
-  exit 1
-fi
-
-
-# Generate configuration files
-mkdir ~/.kube
-cat > ~/.kube/config << EOF
-apiVersion: v1
-preferences: {}
-kind: Config
-
-clusters:
-- cluster:
-    server: ${EKS_URL}
-    certificate-authority-data: ${EKS_CA}
-  name: eks_${PLUGIN_EKS_CLUSTER}
-
-contexts:
-- context:
-    cluster: eks_${PLUGIN_EKS_CLUSTER}
-    user: eks_${PLUGIN_EKS_CLUSTER}
-  name: eks_${PLUGIN_EKS_CLUSTER}
-
-current-context: eks_${PLUGIN_EKS_CLUSTER}
-
-users:
-- name: eks_${PLUGIN_EKS_CLUSTER}
-  user:
-    exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
-      command: aws-iam-authenticator
-      args:
-        - "token"
-        - "-i"
-        - ${PLUGIN_EKS_CLUSTER}
-        - -r
-        - ${PLUGIN_IAM_ROLE_ARN}
-EOF
-
-# kubectl version
+# Perform the new deployment.
 IFS=',' read -r -a DEPLOYMENTS <<< "${PLUGIN_DEPLOYMENT}"
 IFS=',' read -r -a CONTAINERS <<< "${PLUGIN_CONTAINER}"
 for DEPLOY in ${DEPLOYMENTS[@]}; do


### PR DESCRIPTION
This allows us to support executing adhoc kubectl commands if required, rather than just being restricted to the act of updating deployments.

Expected use case is for a small number of applications that require special services, eg updating a configuration map or some other resource at time of deployment.